### PR TITLE
Apply prefers-color-scheme media query to :root instead of :html.

### DIFF
--- a/css/barebones.css
+++ b/css/barebones.css
@@ -76,7 +76,7 @@ html {
 	included for future and an example of defining a different base 'theme'
 */
 @media (prefers-color-scheme: dark) {
-	:html {
+	:root {
 		/* dark theme: light background, dark text, blue accent */
 		--theme-hue: 0;					/* black */
 		--accent-hue: 194;			/* blue */


### PR DESCRIPTION
This fixes the dark mode. Previously, `prefers-color-scheme` wouldn't be applied globally on a website that uses `barebones.css`.

I tested this on Firefox 67. See also [CSS Custom Properties](https://stuffandnonsense.co.uk/blog/redesigning-your-product-and-website-for-dark-mode) for details.