### PR TITLE
Apply dark mode only when viewing website on a screen.

### DIFF
--- a/css/barebones.css
+++ b/css/barebones.css
@@ -75,7 +75,7 @@ html {
 	Note: prefers-color-scheme selector support is still limited, but 
 	included for future and an example of defining a different base 'theme'
 */
-@media (prefers-color-scheme: dark) {
+@media screen and (prefers-color-scheme: dark) {
 	:html {
 		/* dark theme: light background, dark text, blue accent */
 		--theme-hue: 0;					/* black */


### PR DESCRIPTION
When printing a website, a user may want to print the default (light) color scheme in order to reduce toner usage of their printer.
This should ensure that `prefers-color-scheme: dark` only gets applied on media that have a screen.

Please have a look at [this note](https://drafts.csswg.org/mediaqueries-5/#prefers-color-scheme) of the specification for the motivation of this pull request. Thanks!