### PR TITLE
Fix placeholder font color in form fields

### DIFF
--- a/css/barebones.css
+++ b/css/barebones.css
@@ -290,6 +290,7 @@ textarea,
 select {
   height: 38px;
   padding: 6px 10px; /* The 6px vertically centers text on FF, ignored by Webkit */
+  color: var(--text-color-softer);
   background-color: var(--background-color);
   border: 1px solid var(--border-color-softer);
   border-radius: 4px;


### PR DESCRIPTION
Explicitly set color on forms text as placeholders are hard to see when media query selects dark theme.